### PR TITLE
Build: Mantém Java 17 no pom.xml para Compatibilidade da Equipe

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "java.configuration.updateBuildConfiguration": "interactive",
-    "java.compile.nullAnalysis.mode": "automatic"
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.debug.settings.onBuildFailureProceed": true
 }

--- a/systemvigiasus/.mvn/wrapper/maven-wrapper.properties
+++ b/systemvigiasus/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip

--- a/systemvigiasus/pom.xml
+++ b/systemvigiasus/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>17</java.version>
+    <java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
**Resumo da alteração:**
Esta atualização foca na padronização do ambiente de construção (build) do sistema. Após testes locais, identificamos que a atualização para o JDK 21 resolveu problemas críticos de carregamento de bibliotecas do Maven, mas optamos por manter a declaração de versão no pom.xml como Java 17.

**Justificativa Técnica:**

- Compatibilidade Retroativa: O JDK 21 é capaz de compilar e executar o código em conformidade com o Java 17.
- Colaboração: Mantendo o alvo (target) em 17, garantimos que outros membros da equipe (que possuem apenas o JDK 17) consigam compilar e rodar o projeto sem a necessidade de atualizar suas máquinas.
- Estabilidade: Evita a utilização acidental de recursos exclusivos das versões mais novas que poderiam quebrar o deploy em ambientes mais restritos.